### PR TITLE
fix for uncaught errors on postpaid screens

### DIFF
--- a/src/pages/Postpaid/BuyBundle.tsx
+++ b/src/pages/Postpaid/BuyBundle.tsx
@@ -17,6 +17,7 @@ import { TextField } from '../../components/TextField';
 import { Spinner } from '../../components/Spinner';
 import { RadioInput } from '../../components/RadioInput';
 import { generateShortId } from '../../utils/generateShortId';
+import { logger } from '../../utils/logger';
 
 export const BuyBundle = () => {
   const [selectedNumber, setSelectedNumber] = useState<number>(-1);
@@ -43,16 +44,24 @@ export const BuyBundle = () => {
   );
 
   useEffect(() => {
-    getCorporateDetails();
-  }, [getCorporateDetails, getCorporateNumbers]);
+    try {
+      getCorporateDetails();
+    } catch (errorResp) {
+      logger.log(errorResp);
+    }
+  }, [getCorporateDetails]);
 
   useEffect(() => {
     if (corporateData) {
-      getCorporateNumbers({
-        contractNumber: String(corporateData.result.contractNumber),
-        pageNumber: 1,
-        pageSize: 5,
-      });
+      try {
+        getCorporateNumbers({
+          contractNumber: String(corporateData.result.contractNumber),
+          pageNumber: 1,
+          pageSize: 5,
+        });
+      } catch (errorResp) {
+        logger.log(errorResp);
+      }
     }
   }, [corporateData, getCorporateNumbers]);
 

--- a/src/pages/Postpaid/Download.tsx
+++ b/src/pages/Postpaid/Download.tsx
@@ -56,7 +56,11 @@ export const Download = () => {
   );
 
   useEffect(() => {
-    getCorporateDetails();
+    try {
+      getCorporateDetails();
+    } catch (errorResp) {
+      logger.log(errorResp);
+    }
   }, [getCorporateDetails]);
 
   const formik = useFormik({

--- a/src/pages/Postpaid/ManageAccount.tsx
+++ b/src/pages/Postpaid/ManageAccount.tsx
@@ -17,6 +17,7 @@ import { TextField } from '../../components/TextField';
 import { Spinner } from '../../components/Spinner';
 import { RadioInput } from '../../components/RadioInput';
 import { generateShortId } from '../../utils/generateShortId';
+import { logger } from '../../utils/logger';
 
 export const ManageAccount = () => {
   const [selectedNumber, setSelectedNumber] = useState<number>(-1);
@@ -43,16 +44,24 @@ export const ManageAccount = () => {
   );
 
   useEffect(() => {
-    getCorporateDetails();
-  }, [getCorporateDetails, getCorporateNumbers]);
+    try {
+      getCorporateDetails();
+    } catch (errorResp) {
+      logger.log(errorResp);
+    }
+  }, [getCorporateDetails]);
 
   useEffect(() => {
     if (corporateData) {
-      getCorporateNumbers({
-        contractNumber: String(corporateData.result.contractNumber),
-        pageNumber: 1,
-        pageSize: 5,
-      });
+      try {
+        getCorporateNumbers({
+          contractNumber: String(corporateData.result.contractNumber),
+          pageNumber: 1,
+          pageSize: 5,
+        });
+      } catch (errorResp) {
+        logger.log(errorResp);
+      }
     }
   }, [corporateData, getCorporateNumbers]);
 

--- a/src/pages/Postpaid/PayBill.tsx
+++ b/src/pages/Postpaid/PayBill.tsx
@@ -47,7 +47,11 @@ export const PayBill = () => {
   );
 
   useEffect(() => {
-    getCorporateDetails();
+    try {
+      getCorporateDetails();
+    } catch (errorResp) {
+      logger.log(errorResp);
+    }
   }, [getCorporateDetails]);
 
   const [payPostpaidBill, { loading, error }] = usePost<SuccessResp>(


### PR DESCRIPTION
1. Wrapped all lazyFetch calls in a try-catch block to prevent the app from breaking when an exception is thrown.