### PR TITLE
fixes for data pages

### DIFF
--- a/src/customHooks/useRequests.ts
+++ b/src/customHooks/useRequests.ts
@@ -49,7 +49,10 @@ const concatParams = (params?: IParam) => {
 export function useFetch<T>(url: string, params?: IParam) {
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<T>();
-  const [error, setError] = useState();
+  const [error, setError] = useState<{
+    responseCode: number;
+    message: string;
+  } | null>(null);
 
   const refetch = useCallback(
     (fetchParams = params) =>

--- a/src/pages/Data/BuyDataWithCard.tsx
+++ b/src/pages/Data/BuyDataWithCard.tsx
@@ -26,8 +26,10 @@ import { ErrorBox } from '../../components/ErrorBox';
 import { Modal } from '../../components/Modal';
 import { useGlobalStore } from '../../store';
 import useRadioInput from '../../components/RadioInput/useRadioInput';
-import { BorrowEligibilityResp, BundlesResp } from './Interface';
+import { BundlesResp } from './Interface';
 import { logger } from '../../utils/logger';
+import { Spinner } from '../../components/Spinner';
+import { useGetMobileNumbers } from '../../customHooks/useGetMobileNumber';
 
 interface SuccessResp {
   result: {
@@ -38,29 +40,21 @@ interface SuccessResp {
 }
 
 export const BuyDataWithCard: React.FC = () => {
-  const {
-    RadioInput: SelectBundleRadio,
-    checked: selectBundle,
-    setChecked: setSelectBundle,
-  } = useRadioInput(true);
-  const {
-    RadioInput: CustomizeBundleRadio,
-    checked: customizeBundle,
-    setChecked: setCustomizeBundle,
-  } = useRadioInput(false);
+  const { RadioInput: SelectBundleRadio } = useRadioInput(true);
+
   const [activeTab, setactiveTab] = useState(1);
 
   const [buyWithDebitCard, { loading, error }] = usePost<SuccessResp>(
     'Mobility.Account/api/data/BuyDataFromDebitCard',
   );
 
-  const { data: dataEligibility } = useFetch<BorrowEligibilityResp>(
-    'Mobility.Account/api/data/GetBorrowingEligibility',
-  );
+  const { mobileNumbers } = useGetMobileNumbers();
 
-  const { data: bundlesData } = useFetch<BundlesResp>(
-    'Mobility.Account/api/Data/GetBundle',
-  );
+  const {
+    data: bundlesData,
+    error: bundlesError,
+    loading: loadingBundles,
+  } = useFetch<BundlesResp>('Mobility.Account/api/Data/GetBundle');
 
   const [dataPlans, setDataPlans] = useState<
     {
@@ -80,26 +74,6 @@ export const BuyDataWithCard: React.FC = () => {
     }
   }, [bundlesData]);
 
-  const [mobileNumbers, setMobileNumbers] = useState<
-    {
-      label: string;
-      value: string;
-    }[]
-  >([]);
-
-  useEffect(() => {
-    if (dataEligibility) {
-      const mobileResults = dataEligibility.result.borrowingOptions.map(
-        (option) => ({
-          label: option.mobileNumber,
-          value: option.mobileNumber,
-        }),
-      );
-
-      setMobileNumbers(mobileResults);
-    }
-  }, [dataEligibility]);
-
   const {
     state: {
       auth: { user },
@@ -112,7 +86,6 @@ export const BuyDataWithCard: React.FC = () => {
       amount: '',
       email: user?.email,
       dataBundle: '',
-      dataValue: '',
     },
     validationSchema: Yup.object({
       mobileNumber: Yup.string()
@@ -128,6 +101,7 @@ export const BuyDataWithCard: React.FC = () => {
 
   const handleTabChange = () => {
     formik.resetForm();
+
     if (activeTab === 1) {
       return setactiveTab(2);
     }
@@ -221,16 +195,6 @@ export const BuyDataWithCard: React.FC = () => {
     </>
   );
 
-  const bundleHandler = () => {
-    if (selectBundle) {
-      setCustomizeBundle(false);
-      setSelectBundle(false);
-    } else {
-      setCustomizeBundle(false);
-      setSelectBundle(true);
-    }
-  };
-
   return (
     <>
       <PageBody>
@@ -254,172 +218,155 @@ export const BuyDataWithCard: React.FC = () => {
                 </Text>
               </Column>
             </CardStyles.CardHeader>
+
             <Card showOverlayedDesign fullWidth padding="7% 20%">
-              <Row
-                wrap
-                justifyContent="center"
-                alignItems="center"
-                style={{
-                  border: `1px solid ${Colors.lightGreen}`,
-                  padding: '2px',
-                }}
-              >
-                <Column xs={6} style={{ marginBottom: 0 }}>
-                  <Button
-                    fullWidth
-                    variant={activeTab === 1 ? 'tertiary' : 'default'}
-                    onClick={handleTabChange}
-                  >
-                    <Text size={14}>Recharge Self</Text>
-                  </Button>
-                </Column>
-                <Column xs={6} style={{ marginBottom: 0 }}>
-                  <Button
-                    variant={activeTab === 2 ? 'tertiary' : 'default'}
-                    onClick={handleTabChange}
-                    fullWidth
-                  >
-                    <Text size={14}>Recharge others</Text>
-                  </Button>
-                </Column>
-              </Row>
-
-              <SizedBox height={24} />
-              {error && <ErrorBox>{error.message}</ErrorBox>}
-
-              <form onSubmit={formik.handleSubmit}>
-                {activeTab === 1 && (
-                  <TextField
-                    label="Select Phone Number"
-                    placeholder="Select Phone"
-                    dropDown
-                    dropDownOptions={mobileNumbers}
-                    value={formik.values.mobileNumber}
-                    onChange={(e) =>
-                      formik.setFieldValue('mobileNumber', e.target.value)
-                    }
-                    type="tel"
-                    minLength={11}
-                    maxLength={11}
-                    error={getFieldError(
-                      formik.errors.mobileNumber,
-                      formik.touched.mobileNumber,
-                    )}
-                  />
-                )}
-
-                {activeTab === 2 && (
-                  <TextField
-                    label="Recipient phone number"
-                    placeholder="Enter Phone number"
-                    {...formik.getFieldProps('mobileNumber')}
-                    type="tel"
-                    minLength={11}
-                    maxLength={11}
-                    error={getFieldError(
-                      formik.errors.mobileNumber,
-                      formik.touched.mobileNumber,
-                    )}
-                  />
-                )}
-
-                <SizedBox height={16} />
-
-                <Row justifyContent="flex-start">
-                  <Column xs={12} md={5}>
-                    <Text variant="lighter">
-                      <SelectBundleRadio
-                        onClick={() => bundleHandler()}
-                        onKeyDown={() => bundleHandler()}
-                      >
-                        Select bundle
-                      </SelectBundleRadio>
-                    </Text>
-                  </Column>
-
-                  <Column xs={12} md={6}>
-                    <Text variant="lighter">
-                      <CustomizeBundleRadio
-                      // onClick={() => bundleHandler()}
-                      // onKeyDown={() => bundleHandler()}
-                      >
-                        Customize bundle
-                      </CustomizeBundleRadio>
-                    </Text>
-                  </Column>
-                </Row>
-
-                <SizedBox height={16} />
-                {selectBundle && (
-                  <TextField
-                    label="Data Bundle"
-                    placeholder="Select Data Bundle"
-                    dropDown
-                    dropDownOptions={dataPlans}
-                    value={formik.values.dataBundle}
-                    onChange={(e) => {
-                      formik.setFieldValue('dataBundle', e.target.value);
-                      formik.setFieldValue('amount', e.target.value);
+              {loadingBundles ? (
+                <SizedBox height={350}>
+                  <Spinner isFixed>Fetching Data Bundles</Spinner>
+                </SizedBox>
+              ) : (
+                <>
+                  <Row
+                    wrap
+                    justifyContent="center"
+                    alignItems="center"
+                    style={{
+                      border: `1px solid ${Colors.lightGreen}`,
+                      padding: '2px',
                     }}
-                    type="tel"
-                    minLength={11}
-                    maxLength={11}
-                    error={getFieldError(
-                      formik.errors.dataBundle,
-                      formik.touched.dataBundle,
-                    )}
-                  />
-                )}
-
-                {customizeBundle && (
-                  <Row justifyContent="space-between">
-                    <Column xs={12} md={6}>
-                      <TextField
-                        label="Amount in Naira"
-                        placeholder="Enter Amount"
-                        {...formik.getFieldProps('amount')}
-                        type="text"
-                        minLength={11}
-                        maxLength={11}
-                        error={getFieldError(
-                          formik.errors.amount,
-                          formik.touched.amount,
-                        )}
-                      />
+                  >
+                    <Column xs={6} style={{ marginBottom: 0 }}>
+                      <Button
+                        fullWidth
+                        variant={activeTab === 1 ? 'tertiary' : 'default'}
+                        onClick={handleTabChange}
+                      >
+                        <Text size={14}>Recharge Self</Text>
+                      </Button>
                     </Column>
-                    <Column xs={12} md={5}>
-                      <TextField
-                        label="Value in MB/GB"
-                        placeholder=""
-                        {...formik.getFieldProps('datavalue')}
-                        type="text"
-                        minLength={11}
-                        maxLength={11}
-                        error={getFieldError(
-                          formik.errors.dataValue,
-                          formik.touched.dataValue,
-                        )}
-                      />
+                    <Column xs={6} style={{ marginBottom: 0 }}>
+                      <Button
+                        variant={activeTab === 2 ? 'tertiary' : 'default'}
+                        onClick={handleTabChange}
+                        fullWidth
+                      >
+                        <Text size={14}>Recharge others</Text>
+                      </Button>
                     </Column>
                   </Row>
-                )}
 
-                <SizedBox height={20} />
-                <Button type="submit" isLoading={loading} fullWidth>
-                  Pay with debit/credit card
-                </Button>
-                {renderModals()}
-              </form>
+                  <SizedBox height={24} />
 
-              <SizedBox height={20} />
+                  {error && <ErrorBox>{error.message}</ErrorBox>}
 
-              <Row justifyContent="center">
-                <img src={masterCardLogo} alt="masterCardLogo" />
-                <SizedBox width={20} />
-                <img src={verveLogo} alt="verveLogo" />
-                <SizedBox width={10} />
-                <img src={visaLogo} alt="visaLogo" />
-              </Row>
+                  {bundlesError && (
+                    <ErrorBox>
+                      We are currently unable to fetch data bundles, please
+                      reload or try again later
+                    </ErrorBox>
+                  )}
+
+                  <form onSubmit={formik.handleSubmit}>
+                    {activeTab === 1 && (
+                      <TextField
+                        label="Select Phone Number"
+                        placeholder="Select Phone"
+                        dropDown
+                        dropDownOptions={mobileNumbers}
+                        value={formik.values.mobileNumber}
+                        onChange={(e) =>
+                          formik.setFieldValue('mobileNumber', e.target.value)
+                        }
+                        type="tel"
+                        minLength={11}
+                        maxLength={11}
+                        error={getFieldError(
+                          formik.errors.mobileNumber,
+                          formik.touched.mobileNumber,
+                        )}
+                      />
+                    )}
+
+                    {activeTab === 2 && (
+                      <TextField
+                        label="Recipient phone number"
+                        placeholder="Enter Phone number"
+                        {...formik.getFieldProps('mobileNumber')}
+                        type="tel"
+                        minLength={11}
+                        maxLength={11}
+                        error={getFieldError(
+                          formik.errors.mobileNumber,
+                          formik.touched.mobileNumber,
+                        )}
+                      />
+                    )}
+
+                    <SizedBox height={16} />
+
+                    <Row justifyContent="flex-start">
+                      <Column xs={12} md={5}>
+                        <Text variant="lighter">
+                          <SelectBundleRadio>Select bundle</SelectBundleRadio>
+                        </Text>
+                      </Column>
+                    </Row>
+
+                    <SizedBox height={16} />
+                    {activeTab === 1 && (
+                      <TextField
+                        label="Data Bundle"
+                        placeholder="Select Data Bundle"
+                        dropDown
+                        dropDownOptions={dataPlans}
+                        value={formik.values.dataBundle}
+                        onChange={(e) => {
+                          formik.setFieldValue('dataBundle', e.target.value);
+                          formik.setFieldValue('amount', e.target.value);
+                        }}
+                        error={getFieldError(
+                          formik.errors.dataBundle,
+                          formik.touched.dataBundle,
+                        )}
+                      />
+                    )}
+
+                    {activeTab === 2 && (
+                      <TextField
+                        label="Data Bundle"
+                        placeholder="Select Data Bundle"
+                        dropDown
+                        dropDownOptions={dataPlans}
+                        value={formik.values.dataBundle}
+                        onChange={(e) => {
+                          formik.setFieldValue('dataBundle', e.target.value);
+                          formik.setFieldValue('amount', e.target.value);
+                        }}
+                        error={getFieldError(
+                          formik.errors.dataBundle,
+                          formik.touched.dataBundle,
+                        )}
+                      />
+                    )}
+
+                    <SizedBox height={20} />
+                    <Button type="submit" isLoading={loading} fullWidth>
+                      Pay with debit/credit card
+                    </Button>
+                    {renderModals()}
+                  </form>
+
+                  <SizedBox height={20} />
+
+                  <Row justifyContent="center">
+                    <img src={masterCardLogo} alt="masterCardLogo" />
+                    <SizedBox width={20} />
+                    <img src={verveLogo} alt="verveLogo" />
+                    <SizedBox width={10} />
+                    <img src={visaLogo} alt="visaLogo" />
+                  </Row>
+                </>
+              )}
             </Card>
           </Column>
         </Column>

--- a/src/pages/Data/TransferData.tsx
+++ b/src/pages/Data/TransferData.tsx
@@ -22,6 +22,7 @@ import { SuccessBox } from '../../components/SuccessBox';
 import { Modal } from '../../components/Modal';
 import { useGlobalStore } from '../../store';
 import { logger } from '../../utils/logger';
+import { useGetMobileNumbers } from '../../customHooks/useGetMobileNumber';
 
 interface SuccessResp {
   responseCode: number;
@@ -29,6 +30,8 @@ interface SuccessResp {
 }
 
 export const TransferData: React.FC = () => {
+  const { mobileNumbers } = useGetMobileNumbers();
+
   const [transferAirtime, { loading, data, error }] = usePost<SuccessResp>(
     'Mobility.Account/api/Data/Transfer',
   );
@@ -67,7 +70,7 @@ export const TransferData: React.FC = () => {
     try {
       const response = await transferAirtime({
         ...formik.values,
-        mobileNumber: formik.values.recipientMobileNumber,
+        mobileNumber: mobileNumbers && mobileNumbers[0].value,
       });
 
       if (response.data) {
@@ -93,8 +96,9 @@ export const TransferData: React.FC = () => {
           <Text>Hi {user?.firstName}</Text>
           <SizedBox height={15} />
           <Text>
-            You are about to transfer
-            <Text variant="darker">{formik.values.amount}</Text> data to &nbsp;
+            You are about to transfer&nbsp;
+            <Text variant="darker">{formik.values.amount}</Text>mb data to
+            &nbsp;
             <Text variant="darker">{formik.values.recipientMobileNumber}</Text>
           </Text>
           <SizedBox height={10} />
@@ -126,7 +130,6 @@ export const TransferData: React.FC = () => {
         onClose={() => setShowSuccessModal(false)}
         size="sm"
       >
-        {error && <ErrorBox>{error.message}</ErrorBox>}
         <SizedBox height={15} />
         <Column>
           <Text>Hi {user?.firstName}</Text>
@@ -194,7 +197,6 @@ export const TransferData: React.FC = () => {
                   {...formik.getFieldProps('amount')}
                   type="number"
                   minLength={1}
-                  // maxLength={11}
                   error={getFieldError(
                     formik.errors.amount,
                     formik.touched.amount,

--- a/src/pages/Data/index.tsx
+++ b/src/pages/Data/index.tsx
@@ -55,47 +55,55 @@ export const DataPage: React.FC = () => {
           </Text>
           <SizedBox height={32} />
           <Row wrap useAppMargin>
-            <Column useAppMargin xs={6} md={3} lg={2}>
-              <Text size={12} weight={500} color={Colors.grey}>
-                Data Balance
-              </Text>
+            {loading ? (
+              <SizedBox height={50}>
+                <Spinner isFixed>Gathering your balances</Spinner>
+              </SizedBox>
+            ) : (
+              <>
+                <Column useAppMargin xs={6} md={3} lg={2}>
+                  <Text size={12} weight={500} color={Colors.grey}>
+                    Data Balance
+                  </Text>
 
-              <Text size={24} weight={500}>
-                {loading ? <Spinner /> : data?.result.dataModel.balance}
-              </Text>
-              <SizedBox height={10} />
+                  <Text size={24} weight={500}>
+                    {data?.result.dataModel.balance}
+                  </Text>
+                  <SizedBox height={10} />
 
-              <Text size={12} weight={500} color={Colors.grey}>
-                Valid till {data?.result.dataModel.expiryDate}
-              </Text>
-              <SizedBox height={5} />
+                  <Text size={12} weight={500} color={Colors.grey}>
+                    Valid till {data?.result.dataModel.expiryDate}
+                  </Text>
+                  <SizedBox height={5} />
 
-              <Text size={12} weight={500} color={Colors.grey}>
-                {data?.result.dataModel.isRollOver
-                  ? 'Roll-Over Applicable'
-                  : 'Roll-Over not Applicable'}
-              </Text>
-            </Column>
-            <Column useAppMargin xs={6} md={3} lg={2}>
-              <Text size={12} weight={500} color={Colors.grey}>
-                Data Bonus
-              </Text>
-              <Text size={24} weight={500}>
-                {loading ? <Spinner /> : data?.result.dataModel.bonusBalance}
-              </Text>
-              <SizedBox height={10} />
+                  <Text size={12} weight={500} color={Colors.grey}>
+                    {data?.result.dataModel.isRollOver
+                      ? 'Roll-Over Applicable'
+                      : 'Roll-Over not Applicable'}
+                  </Text>
+                </Column>
+                <Column useAppMargin xs={6} md={3} lg={2}>
+                  <Text size={12} weight={500} color={Colors.grey}>
+                    Data Bonus
+                  </Text>
+                  <Text size={24} weight={500}>
+                    {data?.result.dataModel.bonusBalance}
+                  </Text>
+                  <SizedBox height={10} />
 
-              <Text size={12} weight={500} color={Colors.grey}>
-                Valid till {data?.result.dataModel.bonusExpiryDate}
-              </Text>
-              <SizedBox height={5} />
+                  <Text size={12} weight={500} color={Colors.grey}>
+                    Valid till {data?.result.dataModel.bonusExpiryDate}
+                  </Text>
+                  <SizedBox height={5} />
 
-              <Text size={12} weight={500} color={Colors.grey}>
-                {data?.result.dataModel.isRollOver
-                  ? 'Roll-Over Applicable'
-                  : 'Roll-Over not Applicable'}
-              </Text>
-            </Column>
+                  <Text size={12} weight={500} color={Colors.grey}>
+                    {data?.result.dataModel.isRollOver
+                      ? 'Roll-Over Applicable'
+                      : 'Roll-Over not Applicable'}
+                  </Text>
+                </Column>
+              </>
+            )}
           </Row>
         </Column>
       </CardStyles.CardHeader>


### PR DESCRIPTION
1. Reposition the balances loader on the data homepage
2. remove the customized plan option for buying data
3. Ensure that not only the primary number is displayed on the data purchase screens