### PR TITLE
implement package advisor UI

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -22,6 +22,7 @@ export const Modal: React.FC<
     showDefaultFooter,
     onClose = () => null,
     isVisible,
+    showCloseButton,
     ...rest
   } = props;
 
@@ -60,9 +61,11 @@ export const Modal: React.FC<
     ? createPortal(
         <Styles.Modal {...rest}>
           <Card className="child">
-            <Button onClick={closeModal} type="button" className="x-close">
-              x
-            </Button>
+            {showCloseButton && (
+              <Button onClick={closeModal} type="button" className="x-close">
+                x
+              </Button>
+            )}
 
             {header && (
               <Column>
@@ -99,4 +102,8 @@ export const Modal: React.FC<
         modalRoot as HTMLElement,
       )
     : null;
+};
+
+Modal.defaultProps = {
+  showCloseButton: true,
 };

--- a/src/components/Modal/styles.ts
+++ b/src/components/Modal/styles.ts
@@ -20,6 +20,7 @@ export interface IModalProps {
     closeText?: string;
   };
   showDefaultFooter?: boolean;
+  showCloseButton?: boolean;
   onClose?: () => any;
   isVisible?: boolean;
   size?: 'sm' | 'md' | 'lg';
@@ -86,6 +87,10 @@ const Modal = styled.div.attrs({})<IModalProps>`
       outline: none;
       border: none;
     }
+  }
+
+  .child::-webkit-scrollbar {
+    width: 0;
   }
 
   /* 

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -21,7 +21,8 @@ const getChildren = (
 export const Text: React.FC<
   TextProps & { children: string | React.ReactNode }
 > = (props) => {
-  const { children, casing, ...rest } = props;
+  const { children, ...rest } = props;
+  const { casing } = props;
 
   return <Styles.Text {...rest}>{getChildren(children, casing)}</Styles.Text>;
 };

--- a/src/customHooks/useGetActivePlan.ts
+++ b/src/customHooks/useGetActivePlan.ts
@@ -1,4 +1,4 @@
-import { useFetch } from './useRequests';
+import { useFetch, useLazyFetch } from './useRequests';
 
 export interface ActivePlan {
   result: {
@@ -14,6 +14,14 @@ export interface ActivePlan {
 
 export const useGetActivePlan = () => {
   const { data, loading, error, refetch } = useFetch<ActivePlan>(
+    'Mobility.Account/api/Plans/GetActivePlan',
+  );
+
+  return { data, loading, error, refetch };
+};
+
+export const useLazyGetActivePlan = () => {
+  const [refetch, { data, loading, error }] = useLazyFetch<ActivePlan>(
     'Mobility.Account/api/Plans/GetActivePlan',
   );
 

--- a/src/pages/PrepaidPlans/PackageAdvisor.tsx
+++ b/src/pages/PrepaidPlans/PackageAdvisor.tsx
@@ -1,0 +1,272 @@
+import React, { useState } from 'react';
+import { ActivePlan } from '.';
+import { Button } from '../../components/Button';
+import { Column } from '../../components/Column';
+import { ErrorBox } from '../../components/ErrorBox';
+import { Modal } from '../../components/Modal';
+import { RadioInput } from '../../components/RadioInput';
+import { Row } from '../../components/Row';
+import { SizedBox } from '../../components/SizedBox';
+import { Spinner } from '../../components/Spinner';
+import { Text } from '../../components/Text';
+import { useGetMobileNumbers } from '../../customHooks/useGetMobileNumber';
+import { useFetch, usePost } from '../../customHooks/useRequests';
+import { useGlobalStore } from '../../store';
+import { Colors } from '../../themes/colors';
+import { generateShortId } from '../../utils/generateShortId';
+import { logger } from '../../utils/logger';
+import { rem } from '../../utils/rem';
+
+interface PackageResponse {
+  result: [PackageResult];
+  responseCode: number;
+  message: string;
+}
+
+interface PackageResult {
+  id: number;
+  offeringId: string;
+  planName: string;
+  option: string;
+}
+
+interface MigrateSuccessResp {
+  responseCode: number;
+  message: string;
+}
+
+export const PackageAdvisor: React.FC<{
+  showPackageAdvisor: boolean;
+  setShowPackageAdvisor: React.Dispatch<React.SetStateAction<boolean>>;
+  showConfirmationPrompt: boolean;
+  setShowConfirmationPrompt: React.Dispatch<React.SetStateAction<boolean>>;
+  showSuccessModal: boolean;
+  setShowSuccessModal: React.Dispatch<React.SetStateAction<boolean>>;
+  refetchCurrentPlan: () => Promise<{
+    loading: boolean;
+    data: ActivePlan;
+    error: null;
+  }>;
+}> = (props) => {
+  const {
+    setShowPackageAdvisor,
+    showPackageAdvisor,
+    showConfirmationPrompt,
+    setShowConfirmationPrompt,
+    showSuccessModal,
+    setShowSuccessModal,
+    refetchCurrentPlan,
+  } = props;
+  const [selectedPackage, setSelectedPackage] = useState<PackageResult>();
+  const { mobileNumbers } = useGetMobileNumbers();
+
+  const { data, loading, error: packagesError } = useFetch<PackageResponse>(
+    'Mobility.Account/api/Plans/GetPackageAdvisorOptions',
+  );
+
+  const [
+    migrateToPlan,
+    { loading: isMigrating, error: migrationError },
+  ] = usePost<MigrateSuccessResp>('Mobility.Account/api/Plans/MigrateToPlan');
+
+  const {
+    state: {
+      auth: { user },
+    },
+  } = useGlobalStore();
+
+  const handlemigrateToPlan = async () => {
+    try {
+      const response = await migrateToPlan({
+        offeringId: selectedPackage?.offeringId,
+        planName: selectedPackage?.planName,
+        mobileNumber: mobileNumbers ? mobileNumbers[0].value : '',
+      });
+
+      if (response.data) {
+        setShowSuccessModal(true);
+      }
+    } catch (errorResp) {
+      logger.log(errorResp);
+    }
+  };
+
+  const Package: React.FC<PackageResult> = (packageProps) => {
+    const { option } = packageProps;
+    return (
+      <Row
+        style={{
+          padding: '5%',
+          border: `solid ${
+            packageProps.offeringId === selectedPackage?.offeringId
+              ? '2px'
+              : '1px'
+          } ${Colors.darkGreen}`,
+          borderRadius: `${rem(5)}`,
+          marginBottom: `${rem(15)}`,
+          cursor: 'pointer',
+        }}
+        alignItems="center"
+        onClick={() => setSelectedPackage({ ...packageProps })}
+      >
+        <Column xs={1}>
+          <RadioInput
+            checked={packageProps.offeringId === selectedPackage?.offeringId}
+          />
+        </Column>
+        <Column xs={11}>
+          <Text>{option}</Text>
+        </Column>
+      </Row>
+    );
+  };
+
+  if (showSuccessModal) {
+    return (
+      <Modal
+        isVisible={showSuccessModal}
+        onClose={() => {
+          setShowSuccessModal(false);
+        }}
+        size="sm"
+      >
+        <SizedBox height={15} />
+        <Column>
+          <Text>Hi {user?.firstName}</Text>
+          <SizedBox height={15} />
+          <Text>
+            You have successfully migrated to{' '}
+            <Text casing="uppercase">{selectedPackage?.planName}</Text>
+          </Text>
+          <SizedBox height={10} />
+          <Button
+            onClick={() => {
+              setShowSuccessModal(false);
+              setShowConfirmationPrompt(false);
+              setShowPackageAdvisor(false);
+              refetchCurrentPlan();
+            }}
+            fullWidth
+          >
+            Done
+          </Button>
+        </Column>
+      </Modal>
+    );
+  }
+
+  if (showConfirmationPrompt) {
+    return (
+      <Modal
+        isVisible={showConfirmationPrompt}
+        onClose={() => setShowConfirmationPrompt(false)}
+        header={{ title: 'Transaction Confirmation' }}
+        size="sm"
+      >
+        {migrationError && <ErrorBox>{migrationError.message}</ErrorBox>}
+        <SizedBox height={15} />
+        <Column>
+          <Text>Hi {user?.firstName}</Text>
+          <SizedBox height={15} />
+          <Text>
+            You are about to migrate to{' '}
+            <Text variant="darker" casing="uppercase">
+              {selectedPackage?.planName}
+            </Text>{' '}
+            prepaid plan
+          </Text>
+          <SizedBox height={10} />
+          <Row useAppMargin>
+            <Column xs={6} useAppMargin>
+              <Button
+                onClick={handlemigrateToPlan}
+                isLoading={isMigrating}
+                fullWidth
+              >
+                Confirm
+              </Button>
+            </Column>
+            <Column xs={6} useAppMargin>
+              <Button
+                onClick={() => {
+                  setShowConfirmationPrompt(false);
+                }}
+                outline
+                fullWidth
+              >
+                Cancel
+              </Button>
+            </Column>
+          </Row>
+        </Column>
+      </Modal>
+    );
+  }
+
+  return (
+    <Modal
+      isVisible={showPackageAdvisor}
+      onClose={() => setShowPackageAdvisor(false)}
+      size="sm"
+      showCloseButton={false}
+    >
+      <Column style={{ padding: '3% 5% 0% 5%' }}>
+        <Row justifyContent="space-between" alignItems="center">
+          <Text size={24} weight={500}>
+            Package Advisor
+          </Text>
+          <Text
+            size={36}
+            color={Colors.blackGrey}
+            style={{ cursor: 'pointer' }}
+            onClick={() => setShowPackageAdvisor(false)}
+          >
+            X
+          </Text>
+        </Row>
+
+        <SizedBox height={40} />
+
+        <Column>
+          {packagesError && <ErrorBox>{packagesError.message}</ErrorBox>}
+          {loading ? (
+            <SizedBox height={200}>
+              <Spinner isFixed>Fetching Advisory</Spinner>
+            </SizedBox>
+          ) : (
+            <>
+              {data?.result.map((pack) => (
+                <Package key={generateShortId()} {...pack} />
+              ))}
+            </>
+          )}
+        </Column>
+        <SizedBox height={20} />
+
+        {selectedPackage && (
+          <>
+            <Text alignment="center" weight={600}>
+              Got you: Recomended package for you is&nbsp;
+              <Text casing="uppercase">
+                {selectedPackage && selectedPackage.planName}
+              </Text>
+            </Text>
+            <SizedBox height={35} />
+            <Button
+              fullWidth
+              style={{ padding: '5%' }}
+              onClick={() => {
+                setShowConfirmationPrompt(true);
+              }}
+            >
+              Activate&nbsp;
+              <Text casing="uppercase">
+                {selectedPackage && selectedPackage.planName}
+              </Text>
+            </Button>
+          </>
+        )}
+      </Column>
+    </Modal>
+  );
+};

--- a/src/pages/PrepaidPlans/index.tsx
+++ b/src/pages/PrepaidPlans/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Card } from '../../components/Card';
 import { Styles as CardStyles } from '../../components/Card/styles';
 import { PageBody } from '../../components/PageBody';
@@ -16,7 +16,8 @@ import { Button } from '../../components/Button';
 import { Spinner } from '../../components/Spinner';
 import { AsyncImage } from '../../components/AsyncImage';
 import { SinglePlan } from './SinglePlan';
-import { useGetActivePlan } from '../../customHooks/useGetActivePlan';
+import { useLazyGetActivePlan } from '../../customHooks/useGetActivePlan';
+import { PackageAdvisor } from './PackageAdvisor';
 
 export interface ActivePlan {
   result: {
@@ -31,13 +32,20 @@ export interface ActivePlan {
 }
 
 export const PrepaidPlansPage: React.FC = () => {
-  const { data, loading } = useGetActivePlan();
+  const { refetch: refetchCurrentPlan, loading, data } = useLazyGetActivePlan();
+
+  const [showPackageAdvisor, setShowPackageAdvisor] = useState(false);
+  const [showConfirmationPrompt, setShowConfirmationPrompt] = useState(false);
+  const [showSuccessModal, setShowSuccessModal] = useState(false);
 
   const { data: allPlans, loading: allPlansLoading } = useFetch<{
     result: ActivePlan['result'][];
   }>('Mobility.Account/api/Plans/GetAllPlans');
 
   const [selectedPlan, setSelectedPlan] = useState<ActivePlan['result']>();
+  useEffect(() => {
+    refetchCurrentPlan();
+  }, [refetchCurrentPlan]);
 
   if (selectedPlan && allPlans) {
     return <SinglePlan plan={selectedPlan} allPlans={allPlans.result} />;
@@ -66,7 +74,12 @@ export const PrepaidPlansPage: React.FC = () => {
                 padding: '15px',
               }}
             >
-              <Row wrap justifyContent="space-between">
+              <Row
+                wrap
+                justifyContent="space-between"
+                style={{ cursor: 'pointer' }}
+                onClick={() => setShowPackageAdvisor(true)}
+              >
                 <img style={{ all: 'unset' }} src={packageAdvisor} alt="" />
                 <Column xs={9}>
                   <Text color={Colors.blackGrey} weight={600}>
@@ -80,6 +93,8 @@ export const PrepaidPlansPage: React.FC = () => {
             </Card>
 
             <Column>
+              <pre>{JSON.stringify(showPackageAdvisor, null, 2)}</pre>
+
               <Text size={32} weight={500}>
                 Prepaid Plans
               </Text>
@@ -146,6 +161,17 @@ export const PrepaidPlansPage: React.FC = () => {
             ))}
           </Row>
         </>
+      )}
+      {showPackageAdvisor && (
+        <PackageAdvisor
+          showPackageAdvisor={showPackageAdvisor}
+          setShowPackageAdvisor={setShowPackageAdvisor}
+          showConfirmationPrompt={showConfirmationPrompt}
+          setShowConfirmationPrompt={setShowConfirmationPrompt}
+          showSuccessModal={showSuccessModal}
+          setShowSuccessModal={setShowSuccessModal}
+          refetchCurrentPlan={refetchCurrentPlan}
+        />
       )}
     </PageBody>
   );


### PR DESCRIPTION
1. Created the package advisor modal

2. Updated the Text component: 
![image](https://user-images.githubusercontent.com/35603292/94987617-81a46a00-055f-11eb-9c65-987bafb001f8.png)
When casing was destructured along with {...rest}, the casing prop was not going to the <Styles.Text> so I destructured it differently.

3. On the modal component, the close icon was not optional, so I added a prop and set it to true by default.
![image](https://user-images.githubusercontent.com/35603292/94987718-4d7d7900-0560-11eb-8b74-6c41016a5334.png)

4. I needed a lazy refetch for active plan so I added it to the activePlan hook
![image](https://user-images.githubusercontent.com/35603292/94987749-8fa6ba80-0560-11eb-82ec-142cb884dd6f.png)


