### PR TITLE
validate date fields on call and tx history

### DIFF
--- a/src/pages/CallHistory/CallHistoryTable.tsx
+++ b/src/pages/CallHistory/CallHistoryTable.tsx
@@ -40,20 +40,16 @@ export const CallHistoryTable: React.FC<{ trackingId: string }> = (props) => {
       endDate: '',
     },
     validationSchema: Yup.object({
-      startDate: Yup.string().test(
-        'DOB',
-        'Future dates are not allowed',
-        (value) => {
+      startDate: Yup.string()
+        .test('StartDate', 'Future dates are not allowed', (value) => {
           return !isFutureDate(value);
-        },
-      ),
-      endDate: Yup.string().test(
-        'DOB',
-        'Future dates are not allowed',
-        (value) => {
+        })
+        .required('Start date is required'),
+      endDate: Yup.string()
+        .test('EndDate', 'Future dates are not allowed', (value) => {
           return !isFutureDate(value);
-        },
-      ),
+        })
+        .required('End date is required'),
     }),
     onSubmit: async (formData) => {
       await getCallHistory();

--- a/src/pages/CallHistory/CallHistoryTable.tsx
+++ b/src/pages/CallHistory/CallHistoryTable.tsx
@@ -13,7 +13,7 @@ import { SizedBox } from '../../components/SizedBox';
 import { SimpleTable } from '../../components/Table';
 import { TextField } from '../../components/TextField';
 import { Button } from '../../components/Button';
-import { getFieldError } from '../../utils/formikHelper';
+import { getFieldError, isFutureDate } from '../../utils/formikHelper';
 
 interface CallHistoryResp {
   responseCode: number;
@@ -40,8 +40,20 @@ export const CallHistoryTable: React.FC<{ trackingId: string }> = (props) => {
       endDate: '',
     },
     validationSchema: Yup.object({
-      startDate: Yup.date().required('This field is required'),
-      endDate: Yup.date().required('This field is required'),
+      startDate: Yup.string().test(
+        'DOB',
+        'Future dates are not allowed',
+        (value) => {
+          return !isFutureDate(value);
+        },
+      ),
+      endDate: Yup.string().test(
+        'DOB',
+        'Future dates are not allowed',
+        (value) => {
+          return !isFutureDate(value);
+        },
+      ),
     }),
     onSubmit: async (formData) => {
       await getCallHistory();

--- a/src/pages/TransactionHistory/index.tsx
+++ b/src/pages/TransactionHistory/index.tsx
@@ -17,7 +17,7 @@ import { useLazyFetch } from '../../customHooks/useRequests';
 
 import { TextField } from '../../components/TextField';
 import { Button } from '../../components/Button';
-import { getFieldError } from '../../utils/formikHelper';
+import { getFieldError, isFutureDate } from '../../utils/formikHelper';
 import { Spinner } from '../../components/Spinner';
 import { SimpleTable } from '../../components/Table';
 
@@ -50,8 +50,20 @@ export const TransactionHistoryPage: React.FC = () => {
       endDate: '',
     },
     validationSchema: Yup.object({
-      startDate: Yup.date().required('This field is required'),
-      endDate: Yup.date().required('This field is required'),
+      startDate: Yup.string().test(
+        'DOB',
+        'Future dates are not allowed',
+        (value) => {
+          return !isFutureDate(value);
+        },
+      ),
+      endDate: Yup.string().test(
+        'DOB',
+        'Future dates are not allowed',
+        (value) => {
+          return !isFutureDate(value);
+        },
+      ),
     }),
     onSubmit: async (formData) => {
       await getTransactionHistory();

--- a/src/pages/TransactionHistory/index.tsx
+++ b/src/pages/TransactionHistory/index.tsx
@@ -50,20 +50,16 @@ export const TransactionHistoryPage: React.FC = () => {
       endDate: '',
     },
     validationSchema: Yup.object({
-      startDate: Yup.string().test(
-        'DOB',
-        'Future dates are not allowed',
-        (value) => {
+      startDate: Yup.string()
+        .test('StartDate', 'Future dates are not allowed', (value) => {
           return !isFutureDate(value);
-        },
-      ),
-      endDate: Yup.string().test(
-        'DOB',
-        'Future dates are not allowed',
-        (value) => {
+        })
+        .required('Start date is required'),
+      endDate: Yup.string()
+        .test('EndDate', 'Future dates are not allowed', (value) => {
           return !isFutureDate(value);
-        },
-      ),
+        })
+        .required('End date is required'),
     }),
     onSubmit: async (formData) => {
       await getTransactionHistory();


### PR DESCRIPTION
1. Validate date fields on transaction history and call history to prevent future dates. 