### PR TITLE
Disable postpaid sidebar link if user acct is not corporate

### DIFF
--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -153,10 +153,19 @@ export const SideBar: React.FC<ISidebar> = (props) => {
             Prepaid Plans
           </Styles.SideBarLink>
         )}
-        {(isHybrid() || isPostpaid()) && (
+        {isHybrid() || isPostpaid() ? (
           <Styles.SideBarLink
             activeClassName="active-sidebar-link"
             to="/postpaid"
+          >
+            <PostPaidIcon />
+            Postpaid/Corporate
+          </Styles.SideBarLink>
+        ) : (
+          <Styles.SideBarLink
+            to="any"
+            onClick={(e) => e.preventDefault()}
+            style={{ color: `${Colors.grey}` }}
           >
             <PostPaidIcon />
             Postpaid/Corporate

--- a/src/components/ValidateOTP/ConfirmOTP.tsx
+++ b/src/components/ValidateOTP/ConfirmOTP.tsx
@@ -94,7 +94,7 @@ export const ConfirmOTPScreen: React.FC<{
             </Text>
             <SizedBox height={6} />
             <Text weight={300} alignment="center">
-              To access this page, kindly enter the OPT sent to your registered
+              To access this page, kindly enter the OTP sent to your registered
               number
             </Text>
             <SizedBox height={36} />

--- a/src/pages/Settings/ConfirmOTP.tsx
+++ b/src/pages/Settings/ConfirmOTP.tsx
@@ -92,7 +92,7 @@ export const ConfirmOTP: React.FC<{
             </Text>
             <SizedBox height={6} />
             <Text weight={300} alignment="center">
-              Kindly enter the OPT sent to your registered number
+              Kindly enter the OTP sent to your registered number
             </Text>
             <SizedBox height={36} />
             <TextField


### PR DESCRIPTION
1. Disable the postpaid link on the sidebar if the user's account is not corporate