### PR TITLE
change error message for non corporate accounts

### DIFF
--- a/src/pages/Postpaid/Download.tsx
+++ b/src/pages/Postpaid/Download.tsx
@@ -183,7 +183,10 @@ export const Download = () => {
             ) : (
               <>
                 {corporateDataError ? (
-                  <ErrorBox>{corporateDataError?.message}</ErrorBox>
+                  <ErrorBox>
+                    Corporate details were not found for your profile, corporate
+                    details are needed to use this feature
+                  </ErrorBox>
                 ) : (
                   <>
                     <Card

--- a/src/pages/Postpaid/ManageAccount.tsx
+++ b/src/pages/Postpaid/ManageAccount.tsx
@@ -97,7 +97,10 @@ export const ManageAccount = () => {
             ) : (
               <>
                 {corporateDataError ? (
-                  <ErrorBox>{corporateDataError?.message}</ErrorBox>
+                  <ErrorBox>
+                    Corporate details were not found for your profile, corporate
+                    details are needed to use this feature
+                  </ErrorBox>
                 ) : (
                   <>
                     <Card

--- a/src/pages/Postpaid/PayBill.tsx
+++ b/src/pages/Postpaid/PayBill.tsx
@@ -185,7 +185,10 @@ export const PayBill = () => {
             ) : (
               <>
                 {corporateDataError ? (
-                  <ErrorBox>{corporateDataError?.message}</ErrorBox>
+                  <ErrorBox>
+                    Corporate details were not found for your profile, corporate
+                    details are needed to use this feature
+                  </ErrorBox>
                 ) : (
                   <>
                     <Card


### PR DESCRIPTION
1. Modified the error message that shows when a user's account is not corporate to read: 
**" Corporate details were not found for your profile, corporate details are needed to use this feature"**