### PR TITLE
fixes for borrowing and prepaid plans home

### DIFF
--- a/src/pages/Airtime/BorrowAirtime.tsx
+++ b/src/pages/Airtime/BorrowAirtime.tsx
@@ -22,6 +22,7 @@ import { Spinner } from '../../components/Spinner';
 import { logger } from '../../utils/logger';
 import { TextField } from '../../components/TextField';
 import { getFieldError } from '../../utils/formikHelper';
+import { useGetMobileNumbers } from '../../customHooks/useGetMobileNumber';
 
 interface BorrowEligibilityResp {
   result: {
@@ -42,6 +43,7 @@ interface BorrowSuccessResp {
 }
 
 export const BorrowAirtime: React.FC = () => {
+  const { mobileNumbers } = useGetMobileNumbers();
   const [borrowAirtime, { loading, data, error }] = usePost<BorrowSuccessResp>(
     'Mobility.Account/api/Airtime/Borrow',
   );
@@ -52,13 +54,6 @@ export const BorrowAirtime: React.FC = () => {
 
   const [selectedNumber, setSelectedNumber] = useState('');
   const [selectedAmount, setSelectedAmount] = useState<number>();
-
-  const [mobileNumbers, setMobileNumbers] = useState<
-    {
-      label: string;
-      value: string;
-    }[]
-  >([]);
 
   interface BorrowingAmounts {
     [x: string]: {
@@ -79,7 +74,6 @@ export const BorrowAirtime: React.FC = () => {
         }),
       );
 
-      setMobileNumbers(mobileResults);
       setSelectedNumber(mobileResults[0].value);
     }
   }, [dataEligibility]);

--- a/src/pages/Data/BorrowData.tsx
+++ b/src/pages/Data/BorrowData.tsx
@@ -24,6 +24,7 @@ import { logger } from '../../utils/logger';
 import { BorrowEligibilityResp } from './Interface';
 import { generateShortId } from '../../utils/generateShortId';
 import { TextField } from '../../components/TextField';
+import { useGetMobileNumbers } from '../../customHooks/useGetMobileNumber';
 
 interface BorrowSuccessResp {
   responseCode: number;
@@ -41,13 +42,6 @@ export const BorrowData: React.FC = () => {
 
   const [selectedNumber, setSelectedNumber] = useState('');
   const [selectedAmount, setSelectedAmount] = useState<number>();
-
-  const [mobileNumbers, setMobileNumbers] = useState<
-    {
-      label: string;
-      value: string;
-    }[]
-  >([]);
 
   interface BorrowingAmounts {
     [x: string]: {
@@ -68,7 +62,6 @@ export const BorrowData: React.FC = () => {
         }),
       );
 
-      setMobileNumbers(mobileResults);
       setSelectedNumber(mobileResults[0].value);
     }
   }, [dataEligibility]);
@@ -113,6 +106,7 @@ export const BorrowData: React.FC = () => {
 
   const [showConfirmationModal, setShowConfirmationModal] = useState(false);
   const [showSuccessModal, setShowSuccessModal] = useState(false);
+  const { mobileNumbers } = useGetMobileNumbers();
 
   const handleborrowData = async () => {
     try {

--- a/src/pages/PrepaidPlans/index.tsx
+++ b/src/pages/PrepaidPlans/index.tsx
@@ -145,9 +145,7 @@ export const PrepaidPlansPage: React.FC = () => {
                         {plan.name}
                       </Text>
                       <SizedBox height={8} />
-                      <Text casing="sentenceCase" variant="lighter">
-                        {plan.description}
-                      </Text>
+                      <Text variant="lighter">{plan.description}</Text>
                     </Column>
                   </Row>
                 </Card>


### PR DESCRIPTION
1. Fix lowercase description text of prepaid plans card
2. Allow borrowing for secondary numbers